### PR TITLE
Changed CIFS share authentication to a password file ~/.nas-credentials

### DIFF
--- a/ubuntu-server
+++ b/ubuntu-server
@@ -1,4 +1,4 @@
 # Install htop
 sudo apt install htop
 # Edit /etc/fstab to automount the NAS at 192.168.1.169
-sudo echo //192.168.1.169/multimedia /mnt/nas-multimedia cifs username=jesse,iocharset=utf8,file_mode=0777,dir_mode=0777 >> /etc/fstab
+sudo echo "//192.168.1.169/multimedia /mnt/nas-multimedia cifs credentials=/home/jesse/.nas-credentials,iocharset=utf8,sec=ntlm 0 0" >> /etc/fstab


### PR DESCRIPTION
Password file with permissions 600 is better than having plaintext in /etc/fstab (everyone has read access), but convenient because you won't have to enter password at login.